### PR TITLE
Refactored, streamlined, fixups and idiomatized

### DIFF
--- a/caseType.go
+++ b/caseType.go
@@ -7,8 +7,7 @@ type CaseType struct {
 }
 
 // Returns a list of available test case types
-func (c *Client) GetCaseTypes() ([]CaseType, error) {
-	caseTypes := []CaseType{}
-	err := c.sendRequest("GET", "get_case_types", nil, &caseTypes)
-	return caseTypes, err
+func (c *Client) GetCaseTypes() (types []CaseType, err error) {
+	err = c.sendRequest("GET", "get_case_types", nil, &types)
+	return
 }

--- a/casefield.go
+++ b/casefield.go
@@ -35,8 +35,7 @@ type CaseFieldOption struct {
 }
 
 // GetCaseFields returns a list of available case custom fields
-func (c *Client) GetCaseFields() ([]CaseField, error) {
-	caseFields := []CaseField{}
-	err := c.sendRequest("GET", "get_case_fields", nil, &caseFields)
-	return caseFields, err
+func (c *Client) GetCaseFields() (fields []CaseField, err error) {
+	err = c.sendRequest("GET", "get_case_fields", nil, &fields)
+	return
 }

--- a/client.go
+++ b/client.go
@@ -18,7 +18,7 @@ type Client struct {
 	url        string
 	username   string
 	password   string
-	httpClient *http.Client
+	HTTPClient *http.Client
 }
 
 // NewClient returns a new client
@@ -35,7 +35,7 @@ func NewClient(url, username, password string) (c *Client) {
 	}
 	c.url += "index.php?/api/v2/"
 
-	c.httpClient = &http.Client{}
+	c.HTTPClient = http.DefaultClient
 
 	return
 }
@@ -63,13 +63,13 @@ func (c *Client) sendRequest(method, uri string, data, v interface{}) error {
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode > 299 {
+	if resp.StatusCode > 399 {
 		return fmt.Errorf("response: status=%q", resp.Status)
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -37,7 +37,7 @@ func TestSendRequest(t *testing.T) {
 	testClient(t)
 
 	c := NewClient("http://example.com", "testUsername", "testPassword")
-	c.httpClient = NewTestClient(newResponse(`{ "status_id": 1 }`), nil)
+	c.HTTPClient = NewTestClient(newResponse(`{ "status_id": 1 }`), nil)
 
 	testValidGetRequest(t, c)
 	testInvalidGetRequest(t, c)

--- a/milestone.go
+++ b/milestone.go
@@ -1,6 +1,9 @@
 package testrail
 
-import "strconv"
+import (
+	"fmt"
+	"net/url"
+)
 
 // Milestone represents a Milestone
 type Milestone struct {
@@ -22,41 +25,38 @@ type SendableMilestone struct {
 	DueOn       int    `json:"due_on,omitempty"`
 }
 
-// GetMilestone returns the existing milestone milestoneID
-func (c *Client) GetMilestone(milestoneID int) (Milestone, error) {
-	returnMilestone := Milestone{}
-	err := c.sendRequest("GET", "get_milestone/"+strconv.Itoa(milestoneID), nil, &returnMilestone)
-	return returnMilestone, err
+// GetMilestone returns the existing milestone for a given milestoneID
+func (c *Client) GetMilestone(milestoneID int) (ms Milestone, err error) {
+	err = c.sendRequest("GET", fmt.Sprintf("get_milestone/%d", milestoneID), nil, &ms)
+	return
 }
 
 // GetMilestones returns the list of milestones for the project projectID
 // can be filtered by completed status of the milestones
-func (c *Client) GetMilestones(projectID int, isCompleted ...bool) ([]Milestone, error) {
-	uri := "get_milestones/" + strconv.Itoa(projectID)
+func (c *Client) GetMilestones(projectID int, isCompleted ...bool) (milestones []Milestone, err error) {
+	vals := make(url.Values)
+
 	if len(isCompleted) > 0 {
-		uri = uri + "&is_completed=" + btoitos(isCompleted[0])
+		vals.Set("is_completed", boolToString(isCompleted[0]))
 	}
 
-	returnMilestones := []Milestone{}
-	err := c.sendRequest("GET", uri, nil, &returnMilestones)
-	return returnMilestones, err
+	err = c.sendRequest("GET", fmt.Sprintf("get_milestones/%d?%s", projectID, vals.Encode()), nil, &milestones)
+	return
 }
 
 // AddMilestone creates a new milestone on project projectID and returns it
-func (c *Client) AddMilestone(projectID int, newMilestone SendableMilestone) (Milestone, error) {
-	createdMilestone := Milestone{}
-	err := c.sendRequest("POST", "add_milestone/"+strconv.Itoa(projectID), newMilestone, &createdMilestone)
-	return createdMilestone, err
+func (c *Client) AddMilestone(projectID int, newMilestone SendableMilestone) (milestone Milestone, err error) {
+	err = c.sendRequest("POST", fmt.Sprintf("add_milestone/%d", projectID), newMilestone, &milestone)
+	return
 }
 
 // UpdateMilestone updates the existing milestone milestoneID an returns it
-func (c *Client) UpdateMilestone(milestoneID int, updates SendableMilestone) (Milestone, error) {
-	updatedMilestone := Milestone{}
-	err := c.sendRequest("POST", "update_milestone/"+strconv.Itoa(milestoneID), updates, &updatedMilestone)
-	return updatedMilestone, err
+func (c *Client) UpdateMilestone(milestoneID int, updates SendableMilestone) (milestone Milestone, err error) {
+	err = c.sendRequest("POST", fmt.Sprintf("update_milestone/%d", milestoneID), updates, &milestone)
+	return
 }
 
 // DeleteMilestone deletes the milestone milestoneID
 func (c *Client) DeleteMilestone(milestoneID int) error {
-	return c.sendRequest("POST", "delete_milestone/"+strconv.Itoa(milestoneID), nil, nil)
+	return c.sendRequest("POST", fmt.Sprintf("delete_milestone/%d", milestoneID), nil, nil)
 }

--- a/priority.go
+++ b/priority.go
@@ -10,8 +10,7 @@ type Priority struct {
 }
 
 // GetPriorities returns a list of available priorities
-func (c *Client) GetPriorities() ([]Priority, error) {
-	prios := []Priority{}
-	err := c.sendRequest("GET", "get_priorities/", nil, &prios)
-	return prios, err
+func (c *Client) GetPriorities() (priorities []Priority, err error) {
+	err = c.sendRequest("GET", "get_priorities/", nil, &priorities)
+	return
 }

--- a/project.go
+++ b/project.go
@@ -2,7 +2,7 @@ package testrail
 
 import (
 	"fmt"
-	"strconv"
+	"net/url"
 )
 
 // Project represents a Project
@@ -26,46 +26,42 @@ type SendableProject struct {
 }
 
 // GetProject returns the existing project projectID
-func (c *Client) GetProject(projectID int) (Project, error) {
-	returnProject := Project{}
-	err := c.sendRequest("GET", "get_project/"+strconv.Itoa(projectID), nil, &returnProject)
-	return returnProject, err
+func (c *Client) GetProject(projectID int) (project Project, err error) {
+	err = c.sendRequest("GET", fmt.Sprintf("get_project/%d", projectID), nil, &project)
+	return
 }
 
 // GetProjects returns a list available projects
 // can be filtered by completed status of the project
-func (c *Client) GetProjects(isCompleted ...bool) ([]Project, error) {
-	uri := "get_projects"
+func (c *Client) GetProjects(isCompleted ...bool) (projects []Project, err error) {
+	vals := make(url.Values)
+
 	if len(isCompleted) > 0 {
-		uri = uri + "&is_completed=" + btoitos(isCompleted[0])
+		vals.Set("is_completed", boolToString(isCompleted[0]))
 	}
 
-	returnProjects := []Project{}
-	err := c.sendRequest("GET", uri, nil, &returnProjects)
-	return returnProjects, err
+	err = c.sendRequest("GET", fmt.Sprintf("get_projects?%s", vals.Encode()), nil, &projects)
+	return
 }
 
 // AddProject creates a new project and return its
-func (c *Client) AddProject(newProject SendableProject) (Project, error) {
-	createdProject := Project{}
-	err := c.sendRequest("POST", "add_project", newProject, &createdProject)
-	return createdProject, err
+func (c *Client) AddProject(newProject SendableProject) (project Project, err error) {
+	err = c.sendRequest("POST", "add_project", newProject, &project)
+	return
 }
 
 // UpdateProject updates the existing project projectID and returns it
-func (c *Client) UpdateProject(projectID int, updates SendableProject, isCompleted ...bool) (Project, error) {
-	updatedProject := Project{}
-	uri := "update_project/" + strconv.Itoa(projectID)
+func (c *Client) UpdateProject(projectID int, updates SendableProject, isCompleted ...bool) (project Project, err error) {
+	vals := make(url.Values)
 	if len(isCompleted) > 0 {
-		uri = uri + "&is_completed=" + btoitos(isCompleted[0])
+		vals.Set("is_completed", boolToString(isCompleted[0]))
 	}
 
-	fmt.Println(uri)
-	err := c.sendRequest("POST", uri, updates, &updatedProject)
-	return updatedProject, err
+	err = c.sendRequest("POST", fmt.Sprintf("update_project/%d?%s", projectID, vals.Encode()), updates, &project)
+	return
 }
 
 // DeleteProject deletes the project projectID
 func (c *Client) DeleteProject(projectID int) error {
-	return c.sendRequest("POST", "delete_project/"+strconv.Itoa(projectID), nil, nil)
+	return c.sendRequest("POST", fmt.Sprintf("delete_project/%d", projectID), nil, nil)
 }

--- a/resultfield.go
+++ b/resultfield.go
@@ -30,8 +30,7 @@ type ResultFieldOption struct {
 }
 
 // GetResultFields returns a list of available test result custom fields
-func (c *Client) GetResultFields() ([]ResultField, error) {
-	caseFields := []ResultField{}
-	err := c.sendRequest("GET", "get_result_fields", nil, &caseFields)
-	return caseFields, err
+func (c *Client) GetResultFields() (fields []ResultField, err error) {
+	err = c.sendRequest("GET", "get_result_fields", nil, &fields)
+	return
 }

--- a/section.go
+++ b/section.go
@@ -1,6 +1,9 @@
 package testrail
 
-import "strconv"
+import (
+	"fmt"
+	"net/url"
+)
 
 // Section represents a Test Suite Section
 type Section struct {
@@ -30,40 +33,37 @@ type UpdatableSection struct {
 }
 
 // GetSection returns the section sectionID
-func (c *Client) GetSection(sectionID int) (Section, error) {
-	returnSection := Section{}
-	err := c.sendRequest("GET", "get_section/"+strconv.Itoa(sectionID), nil, &returnSection)
-	return returnSection, err
+func (c *Client) GetSection(sectionID int) (section Section, err error) {
+	err = c.sendRequest("GET", fmt.Sprintf("get_section/%d", sectionID), nil, &section)
+	return
 }
 
 // GetSections returns the list of sections of projectID
 // present in suite suiteID, if specified
-func (c *Client) GetSections(projectID int, suiteID ...int) ([]Section, error) {
-	returnSection := []Section{}
-	uri := "get_sections/" + strconv.Itoa(projectID)
+func (c *Client) GetSections(projectID int, suiteID ...int) (sections []Section, err error) {
+	vals := make(url.Values)
 
 	if len(suiteID) > 0 {
-		uri = uri + "&suite_id=" + strconv.Itoa(suiteID[0])
+		vals.Set("suite_id", fmt.Sprintf("%d", suiteID[0]))
 	}
-	err := c.sendRequest("GET", uri, nil, &returnSection)
-	return returnSection, err
+
+	err = c.sendRequest("GET", fmt.Sprintf("get_sections/%d?%s", projectID, vals.Encode()), nil, &sections)
+	return
 }
 
 // AddSection creates a new section on projectID and returns it
-func (c *Client) AddSection(projectID int, newSection SendableSection) (Section, error) {
-	createdSection := Section{}
-	err := c.sendRequest("POST", "add_section/"+strconv.Itoa(projectID), newSection, &createdSection)
-	return createdSection, err
+func (c *Client) AddSection(projectID int, newSection SendableSection) (section Section, err error) {
+	err = c.sendRequest("POST", fmt.Sprintf("add_section/%d", projectID), newSection, &section)
+	return
 }
 
 // UpdateSection updates the section sectionID and returns it
-func (c *Client) UpdateSection(sectionID int, update UpdatableSection) (Section, error) {
-	updatedSection := Section{}
-	err := c.sendRequest("POST", "update_section/"+strconv.Itoa(sectionID), update, &updatedSection)
-	return updatedSection, err
+func (c *Client) UpdateSection(sectionID int, update UpdatableSection) (section Section, err error) {
+	err = c.sendRequest("POST", fmt.Sprintf("update_section/%d", sectionID), update, &section)
+	return
 }
 
 // DeleteSection deletes the section sectionID
 func (c *Client) DeleteSection(sectionID int) error {
-	return c.sendRequest("POST", "delete_section/"+strconv.Itoa(sectionID), nil, nil)
+	return c.sendRequest("POST", fmt.Sprintf("delete_section/%d", sectionID), nil, nil)
 }

--- a/status.go
+++ b/status.go
@@ -14,8 +14,7 @@ type Status struct {
 }
 
 // GetStatuses return the list of all possible statuses
-func (c *Client) GetStatuses() ([]Status, error) {
-	returnStatuses := []Status{}
-	err := c.sendRequest("GET", "get_statuses/", nil, &returnStatuses)
-	return returnStatuses, err
+func (c *Client) GetStatuses() (statuses []Status, err error) {
+	err = c.sendRequest("GET", "get_statuses", nil, &statuses)
+	return
 }

--- a/suite.go
+++ b/suite.go
@@ -1,6 +1,6 @@
 package testrail
 
-import "strconv"
+import "fmt"
 
 // Suite represenst a Test Suite
 type Suite struct {
@@ -23,34 +23,30 @@ type SendableSuite struct {
 }
 
 // GetSuite returns the suite suiteID
-func (c *Client) GetSuite(suiteID int) (Suite, error) {
-	returnSuite := Suite{}
-	err := c.sendRequest("GET", "get_suite/"+strconv.Itoa(suiteID), nil, &returnSuite)
-	return returnSuite, err
+func (c *Client) GetSuite(suiteID int) (suite Suite, err error) {
+	err = c.sendRequest("GET", fmt.Sprintf("get_suite/%d", suiteID), nil, &suite)
+	return
 }
 
 // GetSuites returns the list of suites on project projectID
-func (c *Client) GetSuites(projectID int) ([]Suite, error) {
-	returnSuite := []Suite{}
-	err := c.sendRequest("GET", "get_suites/"+strconv.Itoa(projectID), nil, &returnSuite)
-	return returnSuite, err
+func (c *Client) GetSuites(projectID int) (suites []Suite, err error) {
+	err = c.sendRequest("GET", fmt.Sprintf("get_suites/%d", projectID), nil, &suites)
+	return
 }
 
 // AddSuite creates a new suite on projectID and returns it
-func (c *Client) AddSuite(projectID int, newSuite SendableSuite) (Suite, error) {
-	createdSuite := Suite{}
-	err := c.sendRequest("POST", "add_suite/"+strconv.Itoa(projectID), newSuite, &createdSuite)
-	return createdSuite, err
+func (c *Client) AddSuite(projectID int, newSuite SendableSuite) (suite Suite, err error) {
+	err = c.sendRequest("POST", fmt.Sprintf("add_suite/%d", projectID), newSuite, &suite)
+	return
 }
 
 // UpdateSuite updates the suite suiteID and returns it
-func (c *Client) UpdateSuite(suiteID int, update SendableSuite) (Suite, error) {
-	updatedSuite := Suite{}
-	err := c.sendRequest("POST", "update_suite/"+strconv.Itoa(suiteID), update, &updatedSuite)
-	return updatedSuite, err
+func (c *Client) UpdateSuite(suiteID int, update SendableSuite) (suite Suite, err error) {
+	err = c.sendRequest("POST", fmt.Sprintf("update_suite/%d", suiteID), update, &suite)
+	return
 }
 
 // DeleteSuite delete the suite suiteID
 func (c *Client) DeleteSuite(suiteID int) error {
-	return c.sendRequest("POST", "delete_suite/"+strconv.Itoa(suiteID), nil, nil)
+	return c.sendRequest("POST", fmt.Sprintf("delete_suite/%d", suiteID), nil, nil)
 }

--- a/test.go
+++ b/test.go
@@ -1,6 +1,9 @@
 package testrail
 
-import "strconv"
+import (
+	"fmt"
+	"net/url"
+)
 
 // Test represent a Test
 type Test struct {
@@ -19,21 +22,20 @@ type Test struct {
 }
 
 // GetTest returns the test testID
-func (c *Client) GetTest(testID int) (Test, error) {
-	returnTest := Test{}
-	err := c.sendRequest("GET", "get_test/"+strconv.Itoa(testID), nil, &returnTest)
-	return returnTest, err
+func (c *Client) GetTest(testID int) (test Test, err error) {
+	err = c.sendRequest("GET", fmt.Sprintf("get_test/%d", testID), nil, &test)
+	return
 }
 
 // GetTests returns the list of tests of runID
 // with status statusID, if specified
-func (c *Client) GetTests(runID int, statusID ...[]int) ([]Test, error) {
-	returnTest := []Test{}
-	uri := "get_tests/" + strconv.Itoa(runID)
+func (c *Client) GetTests(runID int, statusID ...[]int) (tests []Test, err error) {
+	vals := make(url.Values)
 
 	if len(statusID) > 0 {
-		uri = applySpecificFilter(uri, "status_id", statusID[0])
+		vals.Set("status_id", intsList(statusID[0]))
 	}
-	err := c.sendRequest("GET", uri, nil, &returnTest)
-	return returnTest, err
+
+	err = c.sendRequest("GET", fmt.Sprintf("get_tests/%d?%s", runID, vals.Encode()), nil, &tests)
+	return
 }

--- a/user.go
+++ b/user.go
@@ -1,6 +1,9 @@
 package testrail
 
-import "strconv"
+import (
+	"fmt"
+	"net/url"
+)
 
 // User represents a User
 type User struct {
@@ -11,22 +14,20 @@ type User struct {
 }
 
 // GetUser returns the user userID
-func (c *Client) GetUser(userID int) (User, error) {
-	returnUser := User{}
-	err := c.sendRequest("GET", "get_user/"+strconv.Itoa(userID), nil, &returnUser)
-	return returnUser, err
+func (c *Client) GetUser(userID int) (user User, err error) {
+	err = c.sendRequest("GET", fmt.Sprintf("get_user/%d", userID), nil, &user)
+	return
 }
 
 // GetUserByEmail returns the user corresponding to email email
-func (c *Client) GetUserByEmail(email string) (User, error) {
-	returnUser := User{}
-	err := c.sendRequest("GET", "get_user_by_email&email="+email, nil, &returnUser)
-	return returnUser, err
+func (c *Client) GetUserByEmail(email string) (user User, err error) {
+	vals := url.Values{"email": []string{email}}
+	err = c.sendRequest("GET", fmt.Sprintf("get_user_by_email?%s", vals.Encode()), nil, &user)
+	return
 }
 
 // GetUsers returns the list of users
-func (c *Client) GetUsers() ([]User, error) {
-	returnUser := []User{}
-	err := c.sendRequest("GET", "get_users", nil, &returnUser)
-	return returnUser, err
+func (c *Client) GetUsers() (users []User, err error) {
+	err = c.sendRequest("GET", "get_users", nil, &users)
+	return
 }

--- a/utils.go
+++ b/utils.go
@@ -1,28 +1,62 @@
 package testrail
 
 import (
-	"strconv"
+	"encoding/json"
+	"fmt"
+	"net/url"
 	"strings"
 )
 
-func applySpecificFilter(uri, request string, filters []int) string {
-	uri = uri + "&" + request + "="
-	for i := 0; i < len(filters); i++ {
-		uri = uri + strconv.Itoa(filters[i]) + ","
-	}
-	uri = trimSuffix(uri, ",")
+type IntList []int
 
-	return uri
+func (il IntList) MarshalJSON() ([]byte, error) {
+	var str []string
+	for _, i := range il {
+		str = append(str, fmt.Sprintf("%d", i))
+	}
+	return json.Marshal(strings.Join(str, ","))
 }
 
-func trimSuffix(s, suffix string) string {
-	if strings.HasSuffix(s, suffix) {
-		s = s[:len(s)-len(suffix)]
+func intsList(ints []int) string {
+	var str []string
+	for _, i := range ints {
+		str = append(str, fmt.Sprintf("%d", i))
 	}
-	return s
+	return strings.Join(str, ",")
 }
 
-func btoitos(b bool) string {
+// loadOptionalFilters takes those RequestFilters and transforms them
+// into a Query string.  You need to pass a *list* of filters here, with
+// optionally the first one being used.
+func loadOptionalFilters(vals url.Values, filters interface{}) {
+	cnt, err := json.Marshal(filters)
+	if err != nil {
+		panic("should only be passing types that we know marshal over here !")
+	}
+
+	var kv []map[string]interface{}
+	err = json.Unmarshal(cnt, &kv)
+	if err != nil {
+		panic("should only pass a list of objects that marshal to map[string]string in here !")
+	}
+
+	if len(kv) == 0 {
+		return
+	}
+
+	for k, v := range kv[0] {
+		switch val := v.(type) {
+		case string:
+			vals.Set(k, val)
+		case float64:
+			vals.Set(k, fmt.Sprintf("%v", val))
+		default:
+			panic(fmt.Sprintf("type %T not supported in loadOptionalFilters", v))
+		}
+	}
+}
+
+func boolToString(b bool) string {
 	if b {
 		return "1"
 	}

--- a/utils.go
+++ b/utils.go
@@ -10,11 +10,7 @@ import (
 type IntList []int
 
 func (il IntList) MarshalJSON() ([]byte, error) {
-	var str []string
-	for _, i := range il {
-		str = append(str, fmt.Sprintf("%d", i))
-	}
-	return json.Marshal(strings.Join(str, ","))
+	return json.Marshal(intsList([]int(il)))
 }
 
 func intsList(ints []int) string {


### PR DESCRIPTION
Streamlined usage of Sprintf instead of strconv.

Streamlined usage of url.Values instead of string concatenation. This
avoids encoding issues and many cases where "&" and "?" were intermixed,
or missing.

Streamlined usage of named returns, for idiomatic 3-6 liners..

Implemented a generic "loadOptionalFilters" instead of the
"applyFiltersFor[this-and-that]" functions. (IntList is part of that)

Opened "httpClient" for people to use their own.

StatusCode > 299 could be a redirect, and wouldn't be an error. >399 are
errors.

btoitos -> boolToString

AssignedtoID -> AssignedToID (for idiomatic Go)

Offest -> Offset

TODO: this thing needs more tests.. (low hanging fruit: loadOptionalValues)