### PR TITLE
Remove omitempty json field tag from SendableEntry.IncludeAll

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -58,7 +58,7 @@ type SendableEntry struct {
 	SuiteID      int    `json:"suite_id"`
 	Name         string `json:"name,omitempty"`
 	AssignedtoID int    `json:"assignedto_id,omitempty"`
-	IncludeAll   bool   `json:"include_all,omitempty"`
+	IncludeAll   bool   `json:"include_all"`
 	CaseIDs      []int  `json:"case_ids,omitempty"`
 	ConfigIDs    []int  `json:"config_ids,omitempty"`
 	Runs         []Run  `json:"runs,omitempty"`


### PR DESCRIPTION
The presence of the omitempty tag on this field makes it functionally
impossible to make a sendable entry that does not IncludeAll CaseIDs.
The TestRail Server API defaults this field to true if omitted and
Golang's JSON encoding rules will omit an explicitly declared false
boolean.