### PR TITLE
Fix type of 'Elapsed' to string in Result struct

### DIFF
--- a/result.go
+++ b/result.go
@@ -10,7 +10,7 @@ type Result struct {
 	CreatedOn         int                `json:"created_on"`
 	CustomStepResults []CustomStepResult `json:"custom_step_results"`
 	Defects           string             `json:"defects"`
-	Elapsed           int                `json:"elapsed"`
+	Elapsed           string             `json:"elapsed"`
 	ID                int                `json:"id"`
 	StatusID          int                `json:"status_id"`
 	TestID            int                `json:"test_id"`


### PR DESCRIPTION
See documentation here: http://docs.gurock.com/testrail-api2/reference-results#get_results

A brief description from the doc:
```elapsed	| timespan	| The amount of time it took to execute the test (e.g. "1m" or "2m 30s")```