### PR TITLE
Add timespan and timestamp types

### DIFF
--- a/result.go
+++ b/result.go
@@ -7,10 +7,10 @@ type Result struct {
 	AssignedtoID      int                `json:"assignedto_id"`
 	Comment           string             `json:"comment"`
 	CreatedBy         int                `json:"created_by"`
-	CreatedOn         int                `json:"created_on"`
+	CreatedOn         timestamp          `json:"created_on"`
 	CustomStepResults []CustomStepResult `json:"custom_step_results"`
 	Defects           string             `json:"defects"`
-	Elapsed           string             `json:"elapsed"`
+	Elapsed           timespan           `json:"elapsed"`
 	ID                int                `json:"id"`
 	StatusID          int                `json:"status_id"`
 	TestID            int                `json:"test_id"`
@@ -48,12 +48,12 @@ type RequestFilterForRunResults struct {
 // SendableResult represents a Test Case result
 // that can be created or updated via the api
 type SendableResult struct {
-	StatusID     int    `json:"status_id,omitempty"`
-	Comment      string `json:"comment,omitempty"`
-	Version      string `json:"version,omitempty"`
-	Elapsed      string `json:"elapsed,omitempty"`
-	Defects      string `json:"defects,omitempty"`
-	AssignedToID int    `json:"assignedto_id,omitempty"`
+	StatusID     int      `json:"status_id,omitempty"`
+	Comment      string   `json:"comment,omitempty"`
+	Version      string   `json:"version,omitempty"`
+	Elapsed      timespan `json:"elapsed,omitempty"`
+	Defects      string   `json:"defects,omitempty"`
+	AssignedToID int      `json:"assignedto_id,omitempty"`
 }
 
 // SendableResults represents a list of run results

--- a/result_test.go
+++ b/result_test.go
@@ -1,0 +1,49 @@
+package testrail
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+const resultsJSON = `[{
+    "id": 3179,
+    "test_id": 91193,
+    "status_id": 5,
+    "created_by": 11,
+    "created_on": 1475001797,
+    "elapsed": "37m"
+}]`
+
+func TestFixedGetResults(t *testing.T) {
+	var results []Result
+	if err := json.Unmarshal([]byte(resultsJSON), &results); err != nil {
+		t.Fatal(err)
+	}
+
+	r := results[0]
+
+	createdOn, err := time.Parse(time.RFC3339, "2016-09-27T18:43:17Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !r.CreatedOn.Equal(createdOn) {
+		t.Fatalf("Got: %v, Expected: %v", r.CreatedOn, createdOn)
+	}
+	if r.Elapsed.Duration != 37*time.Minute {
+		t.Fatalf("Wrong duration: %v", r.Elapsed.Duration)
+	}
+	if r.ID != 3179 {
+		t.Fatalf("Wrong ID: %v", r.ID)
+	}
+	if r.TestID != 91193 {
+		t.Fatalf("Wrong testID: %v", r.TestID)
+	}
+	if r.StatusID != 5 {
+		t.Fatalf("Wrong status: %v", r.StatusID)
+	}
+	if r.CreatedBy != 11 {
+		t.Fatalf("Wrong createdBy: %v", r.CreatedBy)
+	}
+}

--- a/timespan.go
+++ b/timespan.go
@@ -1,0 +1,88 @@
+package testrail
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Timespan field type.
+// e.g. "1m" or "2m 30s" -- similar to time.Duration
+//
+// For a description, see:
+// http://docs.gurock.com/testrail-api2/reference-results
+
+type timespan struct {
+	time.Duration
+}
+
+// Unmarshal TestRail timespan into a time.Duration.
+// Transform TestRail-specific formats into something time.ParseDuration understands:
+//   "4h 5m 6s" => "4h5m6s"
+//   "1d" => "8h"
+//   "1w" => "40h"
+//   "1d 2h" => "8h2h"
+//   "1w 2d 3h" => "40h16h3h"
+func (tsp *timespan) UnmarshalJSON(data []byte) error {
+	const (
+		// These are hardcoded in TestRail.
+		// https://discuss.gurock.com/t/estimate-fields/900
+		daysPerWeek = 5
+		hoursPerDay = 8
+	)
+	var (
+		err  error
+		span string
+	)
+
+	if err = json.Unmarshal(data, &span); err != nil {
+		return err
+	}
+
+	if span == "" {
+		return nil
+	}
+
+	var parts []string
+	for _, p := range strings.Fields(span) {
+		if len(p) < 2 {
+			return fmt.Errorf("%q: sequence is too short", p)
+		}
+		amount, err := strconv.Atoi(p[:len(p)-1])
+		if err != nil {
+			return fmt.Errorf("%q: cannot convert to int: %v", amount, err)
+		}
+		unit := p[len(p)-1]
+		switch unit {
+		case 'd':
+			unit = 'h'
+			amount *= hoursPerDay
+		case 'w':
+			unit = 'h'
+			amount *= daysPerWeek * hoursPerDay
+		}
+		parts = append(parts, fmt.Sprintf("%v%c", amount, unit))
+	}
+
+	tsp.Duration, err = time.ParseDuration(strings.Join(parts, ""))
+	if err != nil {
+		return fmt.Errorf("%q: %v", span, err)
+	}
+	return nil
+}
+
+func (tsp timespan) MarshalJSON() ([]byte, error) {
+	d := tsp.Duration
+
+	if d == 0 {
+		return []byte(`null`), nil
+	}
+
+	h, d := d/time.Hour, d%time.Hour
+	m, d := d/time.Minute, d%time.Minute
+	s := d / time.Second
+
+	return []byte(fmt.Sprintf(`"%dh %dm %ds"`, h, m, s)), nil
+}

--- a/timespan_test.go
+++ b/timespan_test.go
@@ -1,0 +1,75 @@
+package testrail
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestTimespanUnmarshal(t *testing.T) {
+	var testData = []struct{ json, stringDuration string }{
+		{`null`, "0s"},
+		{`"15s"`, "15s"},
+		{`"12m"`, "12m"},
+		{`"11h"`, "11h"},
+		{`"4h 5m 6s"`, "4h5m6s"},
+		{`"1d"`, "8h"},
+		{`"1w"`, "40h"},
+		{`"1d 2h"`, "8h2h"},
+		{`"1w 2d 3h"`, "40h16h3h"},
+	}
+
+	for _, data := range testData {
+		var results []Result
+		js := []byte(fmt.Sprintf(`[{"elapsed":%v}]`, data.json))
+		if err := json.Unmarshal(js, &results); err != nil {
+			t.Fatal(err)
+		}
+
+		r := results[0]
+		expected, err := time.ParseDuration(data.stringDuration)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if r.Elapsed.Duration != expected {
+			t.Fatalf("Wrong duration: %v", r.Elapsed.Duration)
+		}
+	}
+}
+
+func TestTimespanMarshal(t *testing.T) {
+	var testData = []struct{ json, stringDuration string }{
+		{`null`, "0s"},
+		{`"0h 0m 15s"`, "15s"},
+		{`"0h 12m 0s"`, "12m"},
+		{`"11h 0m 0s"`, "11h"},
+		{`"4h 5m 6s"`, "4h5m6s"},
+		{`"8h 0m 0s"`, "8h"},
+		{`"40h 0m 0s"`, "40h"},
+		{`"10h 0m 0s"`, "8h2h"},
+		{`"59h 0m 0s"`, "40h16h3h"},
+	}
+
+	for _, td := range testData {
+		duration, err := time.ParseDuration(td.stringDuration)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		result := Result{
+			Elapsed: timespan{
+				Duration: duration,
+			},
+		}
+		data, err := json.Marshal(result.Elapsed)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if string(data) != td.json {
+			t.Fatalf("Wrong data: %v", string(data))
+		}
+	}
+}

--- a/timestamp.go
+++ b/timestamp.go
@@ -1,0 +1,20 @@
+package testrail
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// UNIX timestamp
+type timestamp struct {
+	time.Time
+}
+
+func (ts *timestamp) UnmarshalJSON(data []byte) error {
+	var seconds int64
+	if err := json.Unmarshal(data, &seconds); err != nil {
+		return err
+	}
+	ts.Time = time.Unix(seconds, 0)
+	return nil
+}


### PR DESCRIPTION
TestRail has specific `timestamp` and `timespan` types:
- `timestamp` is a UNIX timestamp (number of seconds since 1970-01-01). It is currently handled as an `int` in the code. This PR changes it to a custom type based on `time.Time` with automatic unmarshaling from JSON.
- `timespan` is a duration. It is a custom string-based type, currently handled as `string`. This PR adds a custom type based on `time.Duration`, with automatic marshaling/unmarshaling.

With these changes, the API now works with standard Go types for times and durations.